### PR TITLE
Feat/118 Adiciona componente de input

### DIFF
--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -27,4 +27,14 @@
     border: 1px solid $cacau-intenso;
     box-shadow: none;
   }
+
+  &Error {
+    border: 1px solid #e53935;
+    outline: none;
+  }
+  &ErrorMessage {
+    color: #e53935;
+    font-size: $font-sm;
+    margin-top: 0.25rem;
+  }
 }

--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -1,0 +1,30 @@
+@use './../../styles/variables.scss' as *;
+
+.input {
+  display: flex;
+  flex-direction: column;
+
+  &Label {
+    font-size: $font-lg;
+    font-weight: 500;
+    color: black;
+  }
+
+  &Field,
+  &Border {
+    padding: 0.625rem 1.25rem;
+    border-radius: 0.625rem;
+    box-shadow: 0rem 0.25rem 0.25rem 0rem #00000040;
+    max-width: 21.875rem;
+    font-size: $font-md;
+
+    &:focus {
+      outline: 2px solid $marrom-gourmet;
+    }
+  }
+
+  &Border {
+    border: 1px solid $cacau-intenso;
+    box-shadow: none;
+  }
+}

--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -3,6 +3,7 @@
 .input {
   display: flex;
   flex-direction: column;
+  gap: $space-sm;
 
   &Label {
     font-size: $font-lg;
@@ -10,8 +11,7 @@
     color: black;
   }
 
-  &Field,
-  &Border {
+  &Field {
     padding: 0.625rem 1.25rem;
     border-radius: 0.625rem;
     box-shadow: 0rem 0.25rem 0.25rem 0rem #00000040;

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Input } from './Input';
+
+describe('Input component', () => {
+  it('renders with label', () => {
+    render(<Input label="Nome" />);
+    expect(screen.getByLabelText('Nome')).toBeInTheDocument();
+  });
+
+  it('renders without label', () => {
+    render(<Input />);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('applies inputField class when hasBorder is false', () => {
+    render(<Input data-testid="input" />);
+    const input = screen.getByTestId('input');
+    expect(input.className).toMatch(/inputField/);
+  });
+
+  it('applies inputBorder class when hasBorder is true', () => {
+    render(<Input hasBorder data-testid="input" />);
+    const input = screen.getByTestId('input');
+    expect(input.className).toMatch(/inputBorder/);
+  });
+
+  it('passes props to input', () => {
+    render(<Input placeholder="Digite aqui" />);
+    expect(screen.getByPlaceholderText('Digite aqui')).toBeInTheDocument();
+  });
+
+  it('calls onChange when typing', () => {
+    const handleChange = jest.fn();
+    render(<Input onChange={handleChange} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'abc' } });
+    expect(handleChange).toHaveBeenCalled();
+  });
+});

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import styles from './Input.module.scss';
 
 export interface InputProps
@@ -6,12 +7,25 @@ export interface InputProps
   hasBorder?: boolean;
 }
 
-export const Input = ({ label, hasBorder = false, ...props }: InputProps) => {
+export const Input = ({
+  label,
+  hasBorder = false,
+  id,
+  ...props
+}: InputProps) => {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+
   return (
     <div className={styles.input}>
-      <label className={styles.inputLabel}>{label}</label>
+      {label && (
+        <label className={styles.inputLabel} htmlFor={inputId}>
+          {label}
+        </label>
+      )}
       <input
-        className={hasBorder ? styles.inputBorder : styles.inputField}
+        id={inputId}
+        className={`${styles.inputField} ${hasBorder ? styles.inputBorder : ''}`}
         {...props}
       />
     </div>

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -5,12 +5,14 @@ export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   hasBorder?: boolean;
+  error?: string;
 }
 
 export const Input = ({
   label,
   hasBorder = false,
   id,
+  error,
   ...props
 }: InputProps) => {
   const generatedId = useId();
@@ -25,9 +27,11 @@ export const Input = ({
       )}
       <input
         id={inputId}
-        className={`${styles.inputField} ${hasBorder ? styles.inputBorder : ''}`}
+        className={`${styles.inputField} ${hasBorder ? styles.inputBorder : ''} ${error ? styles.inputError : ''}`}
+        aria-invalid={!!error}
         {...props}
       />
+      {error && <span className={styles.inputErrorMessage}>{error}</span>}
     </div>
   );
 };

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,0 +1,19 @@
+import styles from './Input.module.scss';
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  hasBorder?: boolean;
+}
+
+export const Input = ({ label, hasBorder = false, ...props }: InputProps) => {
+  return (
+    <div className={styles.input}>
+      <label className={styles.inputLabel}>{label}</label>
+      <input
+        className={hasBorder ? styles.inputBorder : styles.inputField}
+        {...props}
+      />
+    </div>
+  );
+};

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -21,7 +21,11 @@ export const Input = ({
   return (
     <div className={styles.input}>
       {label && (
-        <label className={styles.inputLabel} htmlFor={inputId}>
+        <label
+          className={styles.inputLabel}
+          aria-labelledby={label}
+          htmlFor={inputId}
+        >
           {label}
         </label>
       )}

--- a/src/components/Input/index.ts
+++ b/src/components/Input/index.ts
@@ -1,0 +1,2 @@
+export { Input } from './Input';
+export type { InputProps } from './Input';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,3 @@
 export * from './HelloWorld';
 export * from './Input';
 export * from './AddToCartButton';
-

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from './HelloWorld';
+export * from './Input';

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -15,3 +15,7 @@ button {
   border: none;
   background: none;
 }
+
+input {
+  border: none;
+}


### PR DESCRIPTION
- Adiciona componente de Input 
- Adiciona a prop ```hasBorder``` para ter o controle de borda (alguns Inputs têm borda no figma)
- Label opcional para ter o nome em cima
- Aceita todos as props do input HTML.
- label com htmlFor para garantir acessibilidade


Versão sem borda:
<img width="358" height="87" alt="image" src="https://github.com/user-attachments/assets/10c42392-d3cd-4396-b6d3-5884a8b7d755" />

Versão com borda:
<img width="391" height="90" alt="image" src="https://github.com/user-attachments/assets/c68a43ea-c09d-4647-90c4-df56123e1559" />

