### PR TITLE
Feat/120: Criação do componente de botão

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,6 @@ coverage/
 .vscode/
 .git/
 .gitignore
+docker-compose.yml
+package-lock.json
+package.json

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import { HelloWorld } from '@components';
+import AddToCartButton from './components/AddToCartButton/AddToCartButton';
 
 function App() {
   return (
     <div>
       <HelloWorld name="Se Doce Fosse" />
+      <AddToCartButton />
     </div>
   );
 }

--- a/src/components/AddToCartButton/AddToCartButton.module.scss
+++ b/src/components/AddToCartButton/AddToCartButton.module.scss
@@ -1,4 +1,5 @@
-@import '../../styles/variables.scss';
+@use 'sass:color';
+@use '../../styles/variables.scss' as *;
 
 .addButton {
   display: flex;
@@ -14,7 +15,7 @@
   transition: background 0.2s ease;
 
   &:hover {
-    background-color: darken($creme-caramelo, 5%);
+    background-color: color.adjust($creme-caramelo, $lightness: -5%);
   }
 
   .label {

--- a/src/components/AddToCartButton/AddToCartButton.module.scss
+++ b/src/components/AddToCartButton/AddToCartButton.module.scss
@@ -14,8 +14,8 @@
   border: none;
   cursor: pointer;
   transition: background 0.2s ease;
-  width: 40px;
-  height: 40px;
+  width: 2.5rem; // 40px
+  height: 2.5rem; // 40px
 
   &:hover {
     background-color: color.adjust($creme-caramelo, $lightness: -5%);
@@ -30,7 +30,7 @@
       display: inline;
     }
 
-    width: 120px;
+    width: 7.5rem; // 120px
     height: auto;
     padding: $space-xs $space-md;
   }
@@ -42,13 +42,13 @@
   justify-content: center;
   gap: $space-xxs;
   padding: $space-xs $space-md;
-  border: 2px solid $marrom-gourmet;
+  border: 0.125rem solid $marrom-gourmet; // 2px
   border-radius: $space-xs;
   background-color: $branco;
   color: $marrom-gourmet;
   font-size: $font-md;
   font-weight: 500;
-  width: 100px;
+  width: 6.25rem; // 100px
 }
 
 .counterButton {

--- a/src/components/AddToCartButton/AddToCartButton.module.scss
+++ b/src/components/AddToCartButton/AddToCartButton.module.scss
@@ -4,8 +4,9 @@
 .addButton {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: $space-xs;
-  padding: $space-xs $space-sm;
+  padding: $space-xs;
   background-color: $creme-caramelo;
   border-radius: $space-xs;
   font-size: $font-sm;
@@ -13,46 +14,56 @@
   border: none;
   cursor: pointer;
   transition: background 0.2s ease;
+  width: 40px;
+  height: 40px;
 
   &:hover {
     background-color: color.adjust($creme-caramelo, $lightness: -5%);
   }
 
   .label {
-    display: none; // mobile first: só ícone
+    display: none;
   }
 
   @include desktop {
     .label {
-      display: inline; // desktop: mostra texto "Adicionar"
+      display: inline;
     }
+
+    width: 120px;
+    height: auto;
+    padding: $space-xs $space-md;
   }
 }
 
 .counterWrapper {
   display: flex;
   align-items: center;
+  justify-content: center;
+  gap: $space-xxs;
+  padding: $space-xs $space-md;
+  border: 2px solid $marrom-gourmet;
+  border-radius: $space-xs;
+  background-color: $branco;
+  color: $marrom-gourmet;
+  font-size: $font-md;
+  font-weight: 500;
+  width: 100px;
 }
 
 .counterButton {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.75rem; // botao menor no mobile
-  height: 1.75rem;
-  border-radius: $space-xs;
-  border: 1px solid $cinza-borda;
-  background-color: $branco;
+  background: transparent;
+  border: none;
+  color: $marrom-gourmet;
+  font-size: $font-lg;
   cursor: pointer;
-  transition: background 0.2s ease;
+  padding: 0;
 
   &:hover {
-    background-color: $cinza-hover;
-  }
-
-  @include desktop {
-    width: 2rem; // botao maior no desktop
-    height: 2rem;
+    opacity: 0.7;
   }
 }
 
@@ -60,6 +71,6 @@
   min-width: 1.5rem;
   text-align: center;
   font-weight: 600;
-  font-size: $font-sm;
+  font-size: $font-md;
   color: $marrom-gourmet;
 }

--- a/src/components/AddToCartButton/AddToCartButton.module.scss
+++ b/src/components/AddToCartButton/AddToCartButton.module.scss
@@ -1,0 +1,64 @@
+@import '../../styles/variables.scss';
+
+.addButton {
+  display: flex;
+  align-items: center;
+  gap: $space-xs;
+  padding: $space-xs $space-sm;
+  background-color: $creme-caramelo;
+  border-radius: $space-xs;
+  font-size: $font-sm;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background-color: darken($creme-caramelo, 5%);
+  }
+
+  .label {
+    display: none; // mobile first: só ícone
+  }
+
+  @include desktop {
+    .label {
+      display: inline; // desktop: mostra texto "Adicionar"
+    }
+  }
+}
+
+.counterWrapper {
+  display: flex;
+  align-items: center;
+}
+
+.counterButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem; // botao menor no mobile
+  height: 1.75rem;
+  border-radius: $space-xs;
+  border: 1px solid $cinza-borda;
+  background-color: $branco;
+  cursor: pointer;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background-color: $cinza-hover;
+  }
+
+  @include desktop {
+    width: 2rem; // botao maior no desktop
+    height: 2rem;
+  }
+}
+
+.counterValue {
+  min-width: 1.5rem;
+  text-align: center;
+  font-weight: 600;
+  font-size: $font-sm;
+  color: $marrom-gourmet;
+}

--- a/src/components/AddToCartButton/AddToCartButton.test.tsx
+++ b/src/components/AddToCartButton/AddToCartButton.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AddToCartButton } from './AddToCartButton';
+
+describe('AddToCartButton', () => {
+  it('deve renderizar estado inicial com label + Adicionar (desktop)', () => {
+    render(<AddToCartButton />);
+    expect(screen.getByText('Adicionar')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /adicionar/i })
+    ).toBeInTheDocument();
+  });
+
+  it('ao clicar, deve trocar para contador [-] 1 [+]', () => {
+    render(<AddToCartButton />);
+    const addButton = screen.getByRole('button', { name: /adicionar/i });
+    fireEvent.click(addButton);
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /diminuir quantidade/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /aumentar quantidade/i })
+    ).toBeInTheDocument();
+  });
+
+  it('incrementa a quantidade ao clicar no botão [+]', () => {
+    render(<AddToCartButton />);
+    fireEvent.click(screen.getByRole('button', { name: /adicionar/i }));
+    const increaseBtn = screen.getByRole('button', {
+      name: /aumentar quantidade/i,
+    });
+
+    fireEvent.click(increaseBtn);
+    fireEvent.click(increaseBtn);
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('decrementa a quantidade ao clicar no botão [-]', () => {
+    render(<AddToCartButton quantity={3} />);
+    const decreaseBtn = screen.getByRole('button', {
+      name: /diminuir quantidade/i,
+    });
+
+    fireEvent.click(decreaseBtn);
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('retorna ao estado inicial quando quantidade volta para 0', () => {
+    render(<AddToCartButton quantity={1} />);
+    const decreaseBtn = screen.getByRole('button', {
+      name: /diminuir quantidade/i,
+    });
+
+    fireEvent.click(decreaseBtn);
+
+    expect(
+      screen.getByRole('button', { name: /adicionar/i })
+    ).toBeInTheDocument();
+  });
+
+  it('chama onQuantityChange sempre que a quantidade muda', () => {
+    const handleChange = jest.fn();
+    render(<AddToCartButton onQuantityChange={handleChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /adicionar/i }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /aumentar quantidade/i })
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /diminuir quantidade/i })
+    );
+
+    // Inicial (0), depois (1), depois (2), depois (1)
+    expect(handleChange).toHaveBeenCalledTimes(4);
+    expect(handleChange).toHaveBeenNthCalledWith(1, 0);
+    expect(handleChange).toHaveBeenNthCalledWith(2, 1);
+    expect(handleChange).toHaveBeenNthCalledWith(3, 2);
+    expect(handleChange).toHaveBeenNthCalledWith(4, 1);
+  });
+});

--- a/src/components/AddToCartButton/AddToCartButton.tsx
+++ b/src/components/AddToCartButton/AddToCartButton.tsx
@@ -1,0 +1,62 @@
+import React, { useState, useEffect } from 'react';
+import styles from './AddToCartButton.module.scss';
+import { FiPlus as Plus, FiMinus as Minus } from 'react-icons/fi';
+
+export type AddToCartButtonProps = {
+  quantity?: number;
+  onQuantityChange?: (quantity: number) => void;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export const AddToCartButton: React.FC<AddToCartButtonProps> = ({
+  quantity: initialQuantity = 0,
+  onQuantityChange,
+  className,
+  ...props
+}) => {
+  const [quantity, setQuantity] = useState(initialQuantity);
+
+  useEffect(() => {
+    onQuantityChange?.(quantity);
+  }, [quantity, onQuantityChange]);
+
+  const handleIncrement = () => setQuantity((prev) => prev + 1);
+  const handleDecrement = () =>
+    setQuantity((prev) => (prev > 0 ? prev - 1 : 0));
+
+  if (quantity === 0) {
+    return (
+      <button
+        {...props}
+        className={`${styles.addButton} ${className || ''}`}
+        onClick={handleIncrement}
+      >
+        <Plus size={16} />
+        <span className={styles.label}>Adicionar</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className={styles.counterWrapper}>
+      <button
+        {...props}
+        className={styles.counterButton}
+        onClick={handleDecrement}
+        aria-label="Diminuir quantidade"
+      >
+        <Minus size={16} />
+      </button>
+      <span className={styles.counterValue}>{quantity}</span>
+      <button
+        {...props}
+        className={styles.counterButton}
+        onClick={handleIncrement}
+        aria-label="Aumentar quantidade"
+      >
+        <Plus size={16} />
+      </button>
+    </div>
+  );
+};
+
+export default AddToCartButton;

--- a/src/components/AddToCartButton/index.ts
+++ b/src/components/AddToCartButton/index.ts
@@ -1,0 +1,2 @@
+export { AddToCartButton } from './AddToCartButton';
+export type { AddToCartButtonProps } from './AddToCartButton';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from './HelloWorld';
+export * from './AddToCartButton';

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -3,6 +3,12 @@ $creme-caramelo: #e8d1a7;
 $verde-pistache: #9d9167;
 $marrom-gourmet: #743014;
 $cacau-intenso: #442d1c;
+$branco: #ffffff;
+$preto: #000000;
+$cinza-claro: #f5f5f5;
+$cinza-hover: #f0f0f0;
+$cinza-borda: #dcdcdc;
+$cinza-texto: #666666;
 
 // Font sizes
 $font-xs: 0.75rem; // 12px


### PR DESCRIPTION
Criação do componente AddToCartButton em src/components/AddToCartButton.

Implementa estados:
Inicial: botão “+ Adicionar” (desktop) / apenas ícone “+” (mobile).
Após clique, vira um contador [-] quantidade [+].
Retorna ao estado inicial quando a quantidade volta a 0.

- - Lógica de incremento/decremento controlada internamente, com suporte a props opcionais quantity e onQuantityChange.
- Estende atributos nativos de <button>
- Estilização mobile-first com variáveis do variables.scss.
- Testes unitários cobrindo renderização inicial, mudança de estado, incremento/decremento, retorno ao estado inicial e chamadas do callback.

## Screenshots
Botão para desktop - estado incial: 
<img width="147" height="63" alt="image" src="https://github.com/user-attachments/assets/4d25983b-2d65-410c-a3fb-2fa1d2eee385" />

Botão para desktop - estado contador: 
<img width="124" height="68" alt="image" src="https://github.com/user-attachments/assets/0a355d51-7d2f-42d0-9cd0-6e07dccf68dd" />


Botão para mobile- estado incial: 
<img width="95" height="77" alt="image" src="https://github.com/user-attachments/assets/321d6757-3b13-4425-95bd-22a829cd3390" />

Botão para mobile- estado contador: 
<img width="194" height="72" alt="image" src="https://github.com/user-attachments/assets/7fad5045-cc52-43e3-88d8-212f321f5335" />
